### PR TITLE
pin base image to specific version

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM jumanjiman/infiniband:7
+FROM jumanjiman/infiniband:7-20160311T2137-git-5ddacd5
 
 # The following environment variables control opensm behavior:
 #


### PR DESCRIPTION
The updated base image resolves security problems
reported by Quay's clair security scanner:
- https://rhn.redhat.com/errata/RHSA-2016-0370.html
- https://rhn.redhat.com/errata/RHSA-2016-0301.html
- https://rhn.redhat.com/errata/RHSA-2016-0428.html
