### PR TITLE
Housecleaning to fix double slashed 'tail -F /var/log/opensm-subnet.lst'

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -3,7 +3,7 @@
 # Load kernel modules.
 /usr/libexec/rdma-init-kernel
 
-touch ${OSM_TMP_DIR}/opensm-subnet.lst
-tail -F ${OSM_TMP_DIR}/opensm-subnet.lst &
+touch ${OSM_TMP_DIR}opensm-subnet.lst
+tail -F ${OSM_TMP_DIR}opensm-subnet.lst &
 
 exec /usr/sbin/opensm -F /etc/rdma/opensm.conf -f stdout $@


### PR DESCRIPTION
This change isn't service impacting, purely just housecleaning.

Given that OSM_TMP_DIR=/var/log/, the start.sh script includes a double slash on process execution for the tail -F /var/log/opensm-subnet.lst command.
This removes the double slash. Alternatively you could change OSM_TMP_DIR=/var/log and leave this unchanged, just for readability.

